### PR TITLE
Phase 2: bump commons-logging 1.0.4 -> 1.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.0.4</version>
+            <version>1.3.4</version>
         </dependency>
         <dependency>
             <groupId>xpp3</groupId>


### PR DESCRIPTION
Upgrades commons-logging from the ancient 1.0.4 (2003) to current 1.3.4. Drop-in compatible; no API changes affecting this codebase. Part of Phase 2 library upgrade sequence.