### PR TITLE
Phase 2: replace log4j 1.2.13 with Reload4j 1.2.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,9 +87,9 @@
             <version>0.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.13</version>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
+            <version>1.2.26</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>


### PR DESCRIPTION
Replaces the ancient \log4j:log4j:1.2.13\ (2006, multiple CVEs) with \ch.qos.reload4j:reload4j:1.2.26\, a maintained drop-in fork that keeps the same \org.apache.log4j.*\ package namespace. Zero source changes needed.