### PR TITLE
Submit-button feedback + autoload order-sync fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2026 Clash of Legends
+Copyright (c) 2004-2026 Clash of Legends
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The Counselor shows you the full map, your generals, wizards, and rogues, enemy 
 
 ## License
 
-Counselor is released under the [MIT License](LICENSE). © 2014-2026 Clash of Legends.
+Counselor is released under the [MIT License](LICENSE). © 2004-2026 Clash of Legends.
 
 ---
 

--- a/src/control/WorldControler.java
+++ b/src/control/WorldControler.java
@@ -767,6 +767,9 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
             } else {
                 doAutoLoadCommands(resultsFile);
             }
+            // Autoload parity with doOpenFile: fetch the server's stored order hash so the order-sync
+            // indicator (and the submit button's at-rest tint) resolve on startup instead of staying grey.
+            refreshOrderSyncFromServer();
             fcOrders.setSelectedFile(resultsFile);
             this.saved = false;
         } catch (BusinessException ex) {

--- a/src/control/WorldControler.java
+++ b/src/control/WorldControler.java
@@ -336,6 +336,7 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
             Toast.show(javax.swing.SwingUtilities.getWindowAncestor(this.getGui()),
                     labels.getString("ORDERS.READY.SUBMIT"),
                     javax.swing.UIManager.getIcon("OptionPane.warningIcon"));
+            this.getGui().blinkSubmitReady(); // pulse the submit button in sync with the ready toast
             this.msgSubmitReady = true;
         }
 
@@ -677,6 +678,7 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
                 this.getGui().setStatusMsg(labels.getString("OPENING: ") + resultsFile.getName());
                 this.getGui().setOpenFileName(resultsFile.getName());
                 this.msgSubmitReady = false;
+                this.getGui().stopSubmitBlink(); // kill any running blink from the previous turn
                 this.saved = false;
                 this.savedWorld = false;
                 doAutoLoadCommands(resultsFile);

--- a/src/gui/MainResultWindowGui.java
+++ b/src/gui/MainResultWindowGui.java
@@ -962,6 +962,64 @@ public class MainResultWindowGui extends javax.swing.JPanel implements Serializa
         orderSyncIndicator.setIcon(makeDot(dot));
         orderSyncIndicator.setText(labels.getString(key) + " ");
         orderSyncIndicator.setToolTipText(labels.getString(key + ".TOOLTIP"));
+        // Submit button (jbSend) at-rest tint follows the same order-sync colour as this indicator.
+        // While a "ready" blink is running it owns the icon, so just remember the target and let the
+        // blink settle onto it when it ends (avoids a stale/racing tint).
+        submitSyncColor = dot;
+        if (submitBlinkTimer == null || !submitBlinkTimer.isRunning()) {
+            recolorSubmit(dot);
+        }
+    }
+
+    // --- Submit button (jbSend) feedback -------------------------------------------------------------
+    // (code-only; no .form change) At rest, the cloud-upload glyph is tinted to the current order-sync
+    // colour (#2). When orders become ready, it blinks blue<->grey in lock-step with the ready toast (#1),
+    // then settles back to the at-rest colour.
+    private java.awt.Color submitSyncColor = new java.awt.Color(0x9E9E9E); // grey until the first sync render
+    private javax.swing.Timer submitBlinkTimer;
+
+    private void recolorSubmit(java.awt.Color c) {
+        if (jbSend != null) {
+            jbSend.setIcon(gui.services.SvgIcon.colored("cloud-upload", TOOLBAR_ICON_SIZE, c));
+        }
+    }
+
+    /**
+     * Blink jbSend blue&lt;-&gt;grey using the ready toast's exact palette + cadence (Toast.FLASH_*), so the
+     * button and the toast pulse together, then settle on the current order-sync colour. Called by the
+     * controller at the "orders ready" moment (once per turn).
+     */
+    public void blinkSubmitReady() {
+        if (jbSend == null) {
+            return;
+        }
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            if (submitBlinkTimer != null && submitBlinkTimer.isRunning()) {
+                submitBlinkTimer.stop(); // never stack blinks
+            }
+            final int[] ticks = {gui.services.Toast.FLASH_TICKS};
+            submitBlinkTimer = new javax.swing.Timer(gui.services.Toast.FLASH_INTERVAL_MS, null);
+            submitBlinkTimer.addActionListener(e -> {
+                if (ticks[0] <= 0) {
+                    submitBlinkTimer.stop();
+                    recolorSubmit(submitSyncColor); // settle to the at-rest sync colour (#2)
+                    return;
+                }
+                recolorSubmit((ticks[0] % 2 == 0) ? gui.services.Toast.FLASH_BG : gui.services.Toast.REST_BG);
+                ticks[0]--;
+            });
+            submitBlinkTimer.start();
+        });
+    }
+
+    /** Stop any running submit blink (e.g. on turn reset) and settle the icon to the at-rest colour. */
+    public void stopSubmitBlink() {
+        javax.swing.SwingUtilities.invokeLater(() -> {
+            if (submitBlinkTimer != null && submitBlinkTimer.isRunning()) {
+                submitBlinkTimer.stop();
+            }
+            recolorSubmit(submitSyncColor);
+        });
     }
 
     /** A small filled status dot with a darker ring, so it reads on either a light or dark status bar. */

--- a/src/gui/services/SvgIcon.java
+++ b/src/gui/services/SvgIcon.java
@@ -20,4 +20,16 @@ public final class SvgIcon {
         icon.setColorFilter(new FlatSVGIcon.ColorFilter(c -> UIManager.getColor("Button.foreground")));
         return icon;
     }
+
+    /**
+     * A {@code size} x {@code size} icon for {@code images/icons/<name>.svg} recoloured to a FIXED
+     * {@code color} (ignores the theme foreground). Used to tint a glyph to a status colour - e.g. the
+     * submit button following the order-sync state. After a light/dark switch the tint persists until
+     * the caller recolours again.
+     */
+    public static Icon colored(String name, int size, java.awt.Color color) {
+        FlatSVGIcon icon = new FlatSVGIcon("images/icons/" + name + ".svg", size, size);
+        icon.setColorFilter(new FlatSVGIcon.ColorFilter(c -> color));
+        return icon;
+    }
 }

--- a/src/gui/services/Toast.java
+++ b/src/gui/services/Toast.java
@@ -35,9 +35,12 @@ public final class Toast {
     private static final int SLIDE_TICK_MS = 15;
     private static final int MAX_WIDTH = 440;      // wrap longer messages instead of growing very wide
 
-    private static final Color REST_BG = new Color(0x1a3c6e);  // resting blue
-    private static final Color FLASH_BG = new Color(0x8a93a3); // grey flash to draw the eye
-    private static final int FLASH_TICKS = 6;                  // ~6 * 150ms toggles (~0.9s) then settle
+    // Public so other widgets (e.g. the submit button's "orders ready" blink) can mirror the exact
+    // flash palette + cadence and stay visually in sync with the toast.
+    public static final Color REST_BG = new Color(0x1a3c6e);  // resting blue
+    public static final Color FLASH_BG = new Color(0x8a93a3); // grey flash to draw the eye
+    public static final int FLASH_TICKS = 6;                  // ~6 * 150ms toggles (~0.9s) then settle
+    public static final int FLASH_INTERVAL_MS = 150;
 
     private static Toast current; // single active toast; EDT-confined, no locking needed
 
@@ -161,7 +164,7 @@ public final class Toast {
     /** Briefly flash the background grey<->blue (~0.9s) so a freshly-shown toast catches the eye. */
     private void startFlash() {
         final int[] ticks = {FLASH_TICKS};
-        flashTimer = new Timer(150, null);
+        flashTimer = new Timer(FLASH_INTERVAL_MS, null);
         flashTimer.addActionListener(e -> {
             if (ticks[0] <= 0) {
                 panel.setBackground(REST_BG);


### PR DESCRIPTION
1. **jbSend feedback (experiment):** at-rest, the cloud-upload glyph is tinted to the current order-sync colour; on 'orders ready' it blinks blue<->grey in lock-step with the ready toast (Toast palette+cadence), then settles. Code-only (no .form); one Timer, stop-before-start, stopped on turn reset. Adds SvgIcon.colored + exposes Toast.REST_BG/FLASH_BG/FLASH_TICKS/FLASH_INTERVAL_MS.
2. **Order-sync indicator bug fix:** doAutoLoad never called refreshOrderSyncFromServer (unlike doOpenFile), so the indicator (and the button tint) stayed grey/UNKNOWN on every autoload/file-association/startup launch even when orders matched. Now fetches on autoload too. All EGF-load paths audited + covered.