### PR TITLE
jpackage: raise heap ceiling 1G -> 2G

### DIFF
--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -148,7 +148,7 @@ jobs:
             --vendor "Clash of Legends" \
             --add-modules java.desktop,java.sql,java.xml,java.naming,java.logging,java.management,jdk.unsupported,jdk.crypto.ec \
             --java-options '-splash:$APPDIR/teaser_whs01.png' \
-            --java-options -Xmx1024M \
+            --java-options -Xmx2048M \
             --java-options "-Dsun.java2d.d3d=false" \
             --java-options "-Dsun.java2d.noddraw=true" \
             --java-options "--add-opens=java.base/java.util=ALL-UNNAMED" \
@@ -178,7 +178,7 @@ jobs:
             --vendor "Clash of Legends" \
             --add-modules java.desktop,java.sql,java.xml,java.naming,java.logging,java.management,jdk.unsupported,jdk.crypto.ec \
             --java-options '-splash:$APPDIR/teaser_whs01.png' \
-            --java-options -Xmx1024M \
+            --java-options -Xmx2048M \
             --java-options "-Dsun.java2d.d3d=false" \
             --java-options "-Dsun.java2d.noddraw=true" \
             --java-options "--add-opens=java.base/java.util=ALL-UNNAMED" \
@@ -210,7 +210,7 @@ jobs:
             --vendor "Clash of Legends" \
             --add-modules java.desktop,java.sql,java.xml,java.naming,java.logging,java.management,jdk.unsupported,jdk.crypto.ec \
             --java-options '-splash:$APPDIR/teaser_whs01.png' \
-            --java-options -Xmx1024M \
+            --java-options -Xmx2048M \
             --java-options "--add-opens=java.base/java.util=ALL-UNNAMED" \
             --java-options "--add-opens=java.base/java.lang=ALL-UNNAMED" \
             --java-options "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED" \


### PR DESCRIPTION
OutOfMemoryError (crash game 860, eadur): heap exhausted at -Xmx1024M during an AWT display-change surface rebuild (VolatileImage backup surfaces recreated en masse) on a big long-running-game map. Raise all 3 jpackage legs to -Xmx2048M. Config-only; ships next release. (Separate from the reload memory leak, still under investigation.)