### PR TITLE
Fix crash: Relationship order param with no target nations

### DIFF
--- a/src/gui/subtabs/SubTabRelacionamento.java
+++ b/src/gui/subtabs/SubTabRelacionamento.java
@@ -49,13 +49,20 @@ public final class SubTabRelacionamento extends TabBase implements Serializable 
         relControl.setTabGui(this);
         //liga actionlisteners para a combo
         jcbNacao.setModel(nacaoComboModel);
+        // Guard the empty-combo case: with no target nations (fog / early turn) the model is empty,
+        // getIndexById returns its 0 default, and setSelectedIndex(0) throws "0 out of bounds" (crash
+        // game 889). Only select + wire the relationship combo when there is actually a target nation.
         int index = nacaoComboModel.getIndexById(vlId[0]);
-        jcbNacao.setSelectedIndex(index);
+        if (index >= 0 && index < jcbNacao.getItemCount()) {
+            jcbNacao.setSelectedIndex(index);
+        }
         jcbNacao.setActionCommand("jcbNacao");
         jcbNacao.addItemListener(relControl);
         //seta model no combo do panel
         GenericoComboObject nacaoAlvoObj = (GenericoComboObject) jcbNacao.getModel().getSelectedItem();
-        setRelacionamentoCombo((Nacao) nacaoAlvoObj.getObject());
+        if (nacaoAlvoObj != null && nacaoAlvoObj.getObject() != null) {
+            setRelacionamentoCombo((Nacao) nacaoAlvoObj.getObject());
+        }
     }
 
     /**


### PR DESCRIPTION
IllegalArgumentException 'setSelectedIndex: 0 out of bounds' (crash game 889, mongo): building a Relationship order parameter when the target-nation combo is empty (no known nations - fog/early turn). GenericoComboBoxModel.getIndexById returns its 0 default on an empty model, so setSelectedIndex(0) throws on the 0-item combo; the following getSelectedItem() would then NPE too. Guard both: only select + wire the relationship combo when a target nation exists. Counselor-only, no lib change.