### PR TITLE
Crash attribution: seed player at startup

### DIFF
--- a/src/client/Main.java
+++ b/src/client/Main.java
@@ -45,6 +45,10 @@ public class Main implements Serializable {
         final SettingsManager sm = SettingsManager.getInstance();
         sm.setConfigurationMode("Client");
         sm.setLanguage(sm.getConfig("language", "en"));
+        // Seed crash attribution with the machine's configured player as early as possible, so a crash
+        // BEFORE any turn loads (or an "uncaught" with no filename in context) still names who it was.
+        // Refined per-game on world load (WorldFacadeCounselor). Empty when no login is configured yet.
+        persistenceCommons.CrashReporter.setSession(0, sm.getConfig("playerLogin", ""));
         String autoload;
         if (args.length == 1) {
             autoload = args[0];


### PR DESCRIPTION
Crash reports before a turn loads (or 'uncaught' with no filename) came through as game=0/player='' because CrashReporter.setSession was only called on world load. Seed it at startup from the machine's configured playerLogin so those crashes still name the owner; the world-load call still refines it per game. Fallback when the per-player token is absent/invalid (Site otherwise resolves the token). Counselor-only.