### PR TITLE
CI: cap Actions artifact retention to stop storage-quota accrual

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,3 +25,6 @@ jobs:
           name: test-results
           path: build/test/results/
           if-no-files-found: ignore
+          # Uploaded on every branch push; keep a short window (debug aid only) so it does not
+          # accumulate against the Actions storage quota. Default is 90 days.
+          retention-days: 7

--- a/.github/workflows/jpackage.yml
+++ b/.github/workflows/jpackage.yml
@@ -233,6 +233,10 @@ jobs:
         with:
           name: installer-${{ matrix.os }}
           path: installer/
+          # This artifact is only the build->release cross-job hand-off; the release page keeps the
+          # installers permanently as release assets. Keep it 1 day so it does not accrue against the
+          # Actions storage quota (hit 2026-07-18; ~150 MB per tagged release across the 3 platforms).
+          retention-days: 1
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Why
Workflow artifacts were uploaded at the **default 90-day retention** and accumulated to **~3 GB**, tripping the org Actions storage quota (releases themselves are unaffected - they use release assets). Old artifacts were pruned manually 2026-07-18; this stops the re-accrual.

## Changes
- **jpackage.yml** - installer artifacts `retention-days: 1`. These are only the `build`->`release` cross-job hand-off; the tagged release keeps the same files permanently as **release assets**, so they need only survive within the run (~150 MB/release across 3 platforms otherwise lingered 90 days).
- **build.yml** - `test-results` `retention-days: 7` (uploaded on every branch push; debug aid only).

No effect on build behavior or release contents.