### PR TITLE
MainMapaGui: do not NPE on the tag when the map window is half-built

### DIFF
--- a/src/gui/MainMapaGui.java
+++ b/src/gui/MainMapaGui.java
@@ -379,6 +379,22 @@ public final class MainMapaGui extends javax.swing.JPanel implements Serializabl
         // x,y are 1x hex pixel coords from MapaManager.doCoordToPosition - scale position + glyph by zoom.
         tagX1x = x; // remember 1x coords so the tag can be re-placed when zoom resolves/changes
         tagY1x = y;
+        if (getJlTag() == null) {
+            /**
+             * The window is not fully built yet, so there is nothing to place. This is reachable
+             * because the constructor publishes `this` to the MapaControler (setTabGui) BEFORE it
+             * creates the tag: setTag() has to run after printMapaGeral, which loads the images
+             * (see the comment on setTag). If the constructor dies in between - a map render
+             * failure, say - the controller is left holding a half-built window, and the next table
+             * sort or row selection arrives here and NPEs on jlTag.
+             *
+             * Bailing out keeps that first, real failure visible in the crash report instead of
+             * burying it under a second, misleading "map tag" crash. The coords above are still
+             * recorded, so the tag lands correctly if the window does finish building.
+             */
+            log.warn("setFocusTag(" + x + "," + y + ") ignored: map window not fully initialised (jlTag null)");
+            return;
+        }
         final Rectangle tagRectangle = new Rectangle(
                 (int) Math.round((x - dx) * zoom), (int) Math.round((y - dy) * zoom),
                 (int) Math.round((ImageManager.HEX_SIZE + 2 * dx) * zoom),
@@ -403,9 +419,12 @@ public final class MainMapaGui extends javax.swing.JPanel implements Serializabl
     }
 
     public void hidefocusTag() {
-        getJlTag().setVisible(false);
         tagX1x = -1; // no tag to re-place on the next zoom change
         tagY1x = -1;
+        if (getJlTag() == null) {
+            return; // half-built window - same reason as setFocusTag, and nothing to hide anyway
+        }
+        getJlTag().setVisible(false);
     }
 
     /*


### PR DESCRIPTION
Crash `311356` (player `jpessoa`, game 904, counselor=911, commons=205).

```
NullPointerException: Cannot invoke "javax.swing.JLabel.setIcon(javax.swing.Icon)"
  because the return value of "gui.MainMapaGui.getJlTag()" is null
  at gui.MainMapaGui.setFocusTag(MainMapaGui.java:386)
  at control.MapaControler.printTag(MapaControler.java:143)
  at gui.tabs.TabPersonagensGui.doPersonagemMuda(TabPersonagensGui.java:416)
  at control.PersonagemControler.valueChanged(PersonagemControler.java:141)
  ... JTable.restoreSortingSelection / toggleSortOrder (clicked a column header)
```

## Why jlTag was null

`MainMapaGui`'s constructor publishes `this` to the controller **before** it creates the tag:

- line 79 `mapaControl.setTabGui(this)` -> the controller can now reach this window
- line 81 `doMapa(mapaControl.printMapaGeral())`
- line 85 `setTag()` -> **this is what creates `jlTag`**

`setTag()` cannot simply move earlier: its own comment says *"chamar depois do printMapaGeral, pois ele carrega todas as imagens"* -- it must follow the map render because that is what loads the images.

For this player line 81 **threw**: crash `311355`, 49 seconds earlier in the same session, was the unknown-landmark `getFeature` NPE on map construction. So the constructor died between publishing `this` and creating the tag, the controller kept a half-built window, and the next column-header sort landed in `setFocusTag` with `jlTag` still null.

The landmark crash itself is **already fixed on master** by PbmCommons `3665c7c` (unknown-landmark fallback), so it ships with the next release. This PR is about the *secondary* crash it caused.

## The fix

Guard the two leaf methods that dereference `jlTag`, and return early:

- `setFocusTag` -- the reported crash
- `hidefocusTag` -- the identical unguarded deref two methods down, also `public` and reached from `MapaControler:140` and `TabBase:140`

Value beyond "stop crashing": the guard keeps the **first, real** failure visible in the crash report instead of burying it under a misleading "map tag" crash. That is exactly what happened here -- the map-tag NPE looked like the bug, and the actual cause was a landmark image 49 seconds earlier.

Focus coords are still recorded before the bail-out, so the tag lands correctly if the window does finish building. When `jlTag` exists, behaviour is byte-identical.

## Not addressed here

The root cause is that the constructor publishes `this` to the `MapaControler` before the object is fully built, so *any* future exception between lines 79 and 85 recreates this class of crash on a different member. Fixing that properly means either deferring `setTabGui` to the end of the constructor (and checking nothing in `printMapaGeral` depends on it -- it likely does) or failing the window construction loudly. That is an init-ordering judgement call, not a guard, so it is left for John.

Compiled clean locally (`ant compile`, JDK 21).