### PR TITLE
Open: ignore an empty file selection instead of crashing

### DIFF
--- a/src/control/WorldControler.java
+++ b/src/control/WorldControler.java
@@ -748,6 +748,12 @@ public class WorldControler extends ControlBase implements Serializable, ActionL
      * @throws HeadlessException
      */
     public void doOpenFile(final File resultsFile) {
+        if (resultsFile == null) {
+            //JFileChooser can answer APPROVE_OPTION with no selection (the file name box was cleared by hand);
+            //the drag-drop and recent-files paths can also hand over nothing. Nothing to open - stay put.
+            log.warn("Open requested with no file selected - ignoring.");
+            return;
+        }
         if (loadingEgf) {
             return; // an open is already in progress; ignore re-entrant menu clicks / drops
         }


### PR DESCRIPTION
Crash id 312226 (game 899, player jchalmeta, counselor=911; still unguarded at master).

`JFileChooser` can answer `APPROVE_OPTION` with `getSelectedFile() == null` when the player clears the file name box and hits Open. `doOpen` passes that straight to `doOpenFile`, which NPEs on `resultsFile.getName()` while building the busy overlay - before any load work starts, so nothing is half-done.

Guard placed at the top of `doOpenFile` rather than in `doOpen`, so the drag-drop / recent-files / autoload callers are covered too. `log.warn` rather than a silent return: a null arriving from autoload would mean a config problem worth seeing.

Ant build green locally (JDK 21).