### PR TITLE
Battle Simulator: simulate on a hex with no city instead of crashing

### DIFF
--- a/src/control/BattleSimulatorControlerNew.java
+++ b/src/control/BattleSimulatorControlerNew.java
@@ -372,7 +372,12 @@ public class BattleSimulatorControlerNew implements Serializable, ChangeListener
             //calcula os fatores da media ponderada.
             int forcaBasica = bsf.getArmyAttackBaseLand(army, army.getLocal());
             int forcaPlus = 0;
-            int modRelacionamento = 100 - nacaoFacade.getBonusRelacionamento(city.getNacao(), army.getNacao());
+            //The simulator builds a dummy Cidade when the hex holds no city (the sliders make it a what-if),
+            //and a dummy has no nation: there is no diplomatic modifier to apply. 100 is the neutral value
+            //(dificuldadeBonus[0 + 3] == 0), so no existing simulation changes - only the path that threw.
+            int modRelacionamento = (city.getNacao() == null)
+                    ? 100
+                    : 100 - nacaoFacade.getBonusRelacionamento(city.getNacao(), army.getNacao());
             //aqui entram os bonus da nacao por terreno/tropa
             final int dano = forcaPlus + (forcaBasica * modRelacionamento / 100);
             ataqueTotal += dano;
@@ -385,6 +390,11 @@ public class BattleSimulatorControlerNew implements Serializable, ChangeListener
 
         //distribui a defesa do cp como dano aos atacantes
         for (ArmySim army : armiesList) {
+            if (qtTrops <= 0) {
+                //no troops on either side of the split (a Blank army was added but never given platoons):
+                //there is nothing to distribute, and the ratio below would divide by zero.
+                break;
+            }
             long danoPer = defesa * exercitoFacade.getQtTropasTotal(army) / qtTrops;
 
             //City round %s: %s with an attack of %s inflicted %s of damage to %s with a defense of %s.


### PR DESCRIPTION
Crash id 312153 (game 901, player rodrigoreismaia, counselor=914 - current at the time).

**NPE.** `BattleCasualtySimulatorNew.setCidade` deliberately builds a dummy `new Cidade()` when the simulated hex holds no city, so the size/loyalty/fortification sliders still drive a what-if. A dummy has no nation, and `doCombatCity` passed it straight to `NacaoFacade.getBonusRelacionamento(city.getNacao(), ...)`, which dereferences the base nation. Fixed client-side: `getBonusRelacionamento` is PbmCommons and shared with the Judge, so its non-null contract stays as is.

Neutral value is 100 - `dificuldadeBonus[0 + 3] == 0`, i.e. exactly what a nation at relationship 0 already yields. It only applies on the path that currently throws, so no existing simulation number moves.

**Divide-by-zero, same method.** The damage split is `defesa * getQtTropasTotal(army) / qtTrops`. `doNewArmy` adds `new ArmySim("Blank", ...)` with an empty platoon map, so a list of only-empty armies gives `qtTrops == 0` -> ArithmeticException on the next Simulate. Guarded. (The loop body is otherwise dead code today; the guard keeps it from becoming next week's crash report.)

Ant build green locally (JDK 21).